### PR TITLE
Swayconfig block fix

### DIFF
--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -19,9 +19,22 @@ endif
 " before i3 load to give i3ConfigKeyword lower priority
 syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActionKeyword,@i3ConfigValue,i3ConfigColor,i3ConfigKeyword
 
+
 runtime! syntax/i3config.vim
 
 " Sway extensions to i3
+
+"" Extend certain keywords into regions to support block syntax
+syn region swayConfigCriteriaBlock start=/\[/ skip=/\\$/ end=/$/ contained contains=i3ConfigCondition,@i3ConfigCommand,i3ConfigSeparator extend
+
+syn region swayConfigNoFocusBlock matchgroup=i3ConfigKeyword start=/no_focus\s\+{$/ end=/^\s*}$/ contains=i3ConfigCondition keepend fold
+
+syn region swayConfigAssignBlock matchgroup=i3ConfigKeyword start=/assign\s\+{$/ end=/^\s*}$/ contains=i3ConfigCriteria,i3ConfigSeparator,@i3ConfigIdent,@i3ConfigColVar keepend fold
+
+syn region swayConfigWindowBlock matchgroup=i3ConfigKeyword start=/for_window\s\+{$/ end=/^\s*}$/ contains=swayConfigCriteriaBlock keepend fold
+
+"" Extend keywords
+
 syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained contained skipwhite nextgroup=i3ConfigOption
 syn keyword i3ConfigOption set plus minus allow deny csd v h t contained contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
 


### PR DESCRIPTION
Sway has supported block syntax for some keywords for a while now (more than a few months, but I'm unsure exactly when) for certain keywords such as `assign`, `for_window`, and `no_focus`.
(ripped from my dotfiles):
```
# ==== Class Assignments & Window Options ====
# TODO: Add more of these
# Assign Applications to default locations
assign {
  [class="Vivaldi"] number $ws2
  [class="discord"] number $ws3
  [class="vesktop"] number $ws3
  [class="Signal"] number $ws4
  [class="Steam"] number $ws5
  [title="Steam"] number $ws5
  [class="Plex"]  number $ws6
  [class="Cider"] number $ws10
}

# Certain Windows should float by default
for_window {
  [title="Activation"] floating enable
  [class="Synthesizer V Studio Pro"] floating enable
  [title="Steam - News"] floating enable
  [title="Steam Settings"] floating enable
  [title="Friends List"] floating enable
}

# Sticky Windows
for_window [instance="file_progress"] sticky enable

# Floating Windows should have a title
for_window {
  [floating class="discord"] border none; opacity 0.75
  [floating] border normal
}

#Don't automatically focus on popped windows
no_focus {
  [window_role="pop-up"]
  [window_role="splash"]
}

no_focus [window_role="splash"]

#Inhibit Idling if:
for_window {
  [class="Plex"] inhibit_idle visible
  [floating class="discord"] inhibit_idle visible
}
```

Creating this PR to add highlighting and support for this. Apologies for any mistakes, it's my first time messing with vim syntax files.